### PR TITLE
Update multicluster clusterconfiguration command

### DIFF
--- a/sig-multicluster/how-to-setup-multicluster-on-kubesphere/README.md
+++ b/sig-multicluster/how-to-setup-multicluster-on-kubesphere/README.md
@@ -120,7 +120,7 @@ The component [Tower](https://github.com/kubesphere/tower) of KubeSphere is used
   3. Change the ClusterConfiguration of the ks-installer and input the the address you set before.
 
         ```shell
-        $ kubectl -n kubesphere-system edit cm kubesphere-config
+        $ kubectl -n kubesphere-system edit clusterconfiguration ks-installer
 
         multicluster:
             clusterRole: host


### PR DESCRIPTION
Signed-off-by: Sherlock113 <sherlockxu@yunify.com>

I think users need to edit clusterconfiguration of ks-installer instead of configmap.

BTW, the ZH-CN version is correct.