### PR TITLE
Backup kubesphere/community to gitee.com

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -1,0 +1,22 @@
+name: Backup Git repository
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+    - master
+
+jobs:
+  BackupGit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - name: Sync to gitee
+      uses: Yikun/hub-mirror-action@master
+      with:
+        src: github/kubesphere
+        dst: gitee/kubesphere
+        white_list: 'community'
+        dst_key: ${{ secrets.GITEE_PRIVATE_KEY }}
+        dst_token: ${{ secrets.GITEE_TOKEN}}
+        account_type: org


### PR DESCRIPTION
We'll have [a workshop in Beijing](https://github.com/kubesphere/community/pull/266). During this activity, the participants will record their jobs with issues. Considering this situation, there're several benefits if we backup this repository to gitee.com.

* Unlikely meet the network issues
* Using gitee.com as a separate repository to having Chinese issues
* Get more potential users from gitee.com

Actually, we already have some repositories in gitee.com. See https://github.com/kubesphere/website/pull/521
You can get all the details about this [GitHub Actions](https://github.com/Yikun/hub-mirror-action).
