### PR TITLE
Add code review guide doc, pr author guide and coding conventions

### DIFF
--- a/developer-guide/development/code-review-guide.md
+++ b/developer-guide/development/code-review-guide.md
@@ -5,7 +5,7 @@
 
 The primary purpose of code review is to make sure that the overall health of KubeSphere's code base is improving over time.
 
-**In general, reviewers should favor approving a CL once it is in a state where it definitely improves the overall code health of the system being worked on, even if the CL isn’t perfect.**
+**In general, reviewers should favor approving a PR once it is in a state where it definitely improves the overall code health of the system being worked on, even if the PR isn’t perfect.**
 
 ### Mentoring
 
@@ -44,7 +44,7 @@ Now that you know [what to look for](), what’s the most efficient way to manag
 
 * Does the change make sense? Does it have a good description?
 * Look at the most important part of the change first. Is it well-designed overall?
-* Look at the rest of the CL in an appropriate sequence.
+* Look at the rest of the PR in an appropriate sequence.
 
 
 ## How to write code review comments

--- a/developer-guide/development/code-review-guide.md
+++ b/developer-guide/development/code-review-guide.md
@@ -33,7 +33,7 @@ In doing a code review, you should make sure that:
 * Tests are well-designed.
 * The developer used clear names for everything.
 * Comments are clear and useful, and mostly explain **why** instead of **what**.
-* Code is appropriately documented (generally in g3doc).
+* Code is appropriately documented.
 * The code conforms to our style guides.
 
 Make sure to review **every line** of code you’ve been asked to review, look at the **context**, make sure you’re **improving code health**, and compliment developers on **good things** that they do.

--- a/developer-guide/development/code-review-guide.md
+++ b/developer-guide/development/code-review-guide.md
@@ -1,0 +1,57 @@
+# Code Review Guide
+> This documentation is mostly from [Google's Engineering Practices documentation](https://google.github.io/eng-practices/), we borrowed some highlights. It's highly recommended to read the original documentation.
+
+## The Standard of Code Review
+
+The primary purpose of code review is to make sure that the overall health of KubeSphere's code base is improving over time.
+
+**In general, reviewers should favor approving a CL once it is in a state where it definitely improves the overall code health of the system being worked on, even if the CL isn’t perfect.**
+
+### Mentoring
+
+Code review can have an important function of teaching developers something new about a language, a framework, or general software design principles. It’s always fine to leave comments that help a developer learn something new. Sharing knowledge is part of improving the code health of a system over time. 
+
+### Principles
+* Technical facts and data overrule opinions and personal preferences.
+* On matters of style, [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments) is the authority.
+* Aspects of software design are almost never a pure style issue or just a personal preference.
+
+
+## What to look for in a code review
+
+### Summary
+
+In doing a code review, you should make sure that:
+
+* The code is well-designed.
+* The functionality is good for the users of the code.
+* Any UI changes are sensible and look good.
+* Any parallel programming is done safely.
+* The code isn’t more complex than it needs to be.
+* The developer isn’t implementing things they *might* need in the future but don’t know they need now.
+* Code has appropriate unit tests.
+* Tests are well-designed.
+* The developer used clear names for everything.
+* Comments are clear and useful, and mostly explain **why** instead of **what**.
+* Code is appropriately documented (generally in g3doc).
+* The code conforms to our style guides.
+
+Make sure to review **every line** of code you’ve been asked to review, look at the **context**, make sure you’re **improving code health**, and compliment developers on **good things** that they do.
+
+## Navigating a PR in review Summary
+
+Now that you know [what to look for](), what’s the most efficient way to manage a review that’s spread across multiple files?
+
+* Does the change make sense? Does it have a good description?
+* Look at the most important part of the change first. Is it well-designed overall?
+* Look at the rest of the CL in an appropriate sequence.
+
+
+## How to write code review comments
+
+### Summary
+
+* Be kind.
+* Explain your reasoning.
+* Balance giving explicit directions with just pointing out problems and letting the developer decide.
+* Encourage developers to simplify code or add code comments instead of just explaining the complexity to you.

--- a/developer-guide/development/coding-conventions.md
+++ b/developer-guide/development/coding-conventions.md
@@ -1,0 +1,52 @@
+# KubeSphere Conventions
+
+> This doc mostly from [coding conventions](https://github.com/kubernetes/community/blob/master/contributors/guide/coding-conventions.md) of Kubernetes community. Some modifications are made to be applicable for our case. 
+
+## Coding conventions
+* Bash
+    * Ensure that build, release, test, and cluster-management scripts run on macOS
+
+* Go
+    * Make sure you followed style from [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments) and [Effective Go](https://golang.org/doc/effective_go).
+    * Comment your code.
+        * [Go's commenting conventions](https://blog.golang.org/godoc)
+        * If reviewers ask questions about why the code is the way it is, that's the sign that comments might be helpful.
+    * Command-line flags should use dashes, not underscores.
+    * Naming
+        * Please consider package name when selecting an interface name, and avoid redundancy.
+            * e.g.: `storeg.Interface` is better than `storage.StorageInterface`
+        * Do not use uppercase characters, underscores, or dashes in package names.
+        * Please consider parent directory name when choosing a package name.
+            * so pkg/controllers/autoscaler/foo.go should say package autoscaler not package autoscalercontroller.
+            * Importers can use a different name if they need to disambiguate.
+
+* [Logging](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md) 
+
+    * Use [klog](http://godoc.org/github.com/kubernetes/klog) instead of [log](http://golang.org/pkg/log/), klog is globally perferred to log for better runtime control.
+    * Shared libraries, such as `kubsphere client-go`, should not use `klog.ErrorS()` and `klog.InfoS()`, but just return `error`, because client libraries may be used in CLI UIs that wish to control output.
+    * `klog` conventions
+        * klog.ErrorS() - Errors should be used to indicate unexpected behaviors in code, like unexpected errors returned by subroutine function calls. 
+        * klog.InfoS() - Structured logs to the INFO log. It has multiple levels:
+            * klog.V(0) - Generally useful for this to ALWAYS be visible to an operator
+            * klog.V(1) - A reasonable default log level if you don't want verbosity.
+            * klog.V(2) - Useful steady state information about the service and important log messages that may correlate to significant changes in the system. This is the recommended default log level for most systems.
+            * klog.V(3) - Extended information about changes
+            * klog.V(4) - Debug level verbosity
+            * klog.V(5) - Trace level verbosity
+
+## Testing conventions
+* All new packages and most new significant functionality must come with unit tests.
+* Table-driven tests are preferred for testing multiple scenarios/inputs; for example, see [TestNamespaceAuthorization](https://git.k8s.io/kubernetes/test/integration/auth/auth_test.go)
+* Significant features should come with integration (test/integration) and/or end-to-end (test/e2e) tests
+* Unit tests must pass on macOS and Linux platforms.
+* Avoid waiting for a short amount of time (or without waiting) and expect an asynchronous thing to happen (e.g. wait for 1 seconds and expect a Pod to be running). Wait and retry instead.
+ 
+## Directory and file conventions
+* Avoid package sprawl. Find an appropriate subdirectory for new packages. 
+    * Libraries with no more appropriate home belong in new package subdirectories of pkg/util
+* Avoid general utility packages. Packages called "util" are suspect. Instead, derive a name that describes your desired function. For example, the utility functions dealing with waiting for operations are in the "wait" package and include functionality like Poll. So the full name is wait.Poll
+* All filenames should be lowercase.
+* Go source files and directories use underscores, not dashes
+    * Package directories should generally avoid using separators as much as possible (when packages are multiple words, they usually should be in nested subdirectories).
+* **Document directories** and filenames should use dashes rather than underscores
+

--- a/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
+++ b/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
@@ -1,0 +1,110 @@
+# The PR author's guide to getting through code review
+
+> This documentation is mostly borrowed from [Google's Engineering Practices documentation](https://google.github.io/eng-practices/), we changed the term `CL(Change List)` to `PR(Pull Request)` to make it more applicable for our case .
+
+## Writing good PR descriptions
+
+A PR description is a public record of what change is being made and why it was made. It will become a permanent part of our code base, and will possibly be read by hundreds of people other than your reviewers over the years.
+
+Future developers will search for your PR based on its description. Someone in the future might be looking for your change because of a faint memory of its relevance but without the specifics handy. If all the important information is in the code and not the description, it’s going to be a lot harder for them to locate your PR.
+
+### First Line
+
+* Short summary of what is being done.
+* Complete sentence, written as though it was an order.
+* Follow by empty line.
+
+The first line of a PR description should be a short summary of specifically what is being done by the PR, followed by a blank line.
+
+Try to keep your first line short, focused, and to the point. The clarity and utility to the reader should be the top concern.
+
+### Body is Informative
+
+The rest of the description should be informative. It might include a brief description of the problem that’s being solved, and why this is the best approach. If there are any shortcomings to the approach, they should be mentioned. If relevant, include background information such as **issue numbers**, **benchmark results**, and links to **design documents**.
+
+### Bad PR Descriptions
+
+"Fix bug" is an inadequate PR description. What bug? What did you do to fix it? Other similarly bad descriptions include:
+
+* "Fix build."
+* "Add patch."
+* "Moving code from A to B."
+* "Phase 1."
+* "Add convenience functions."
+* "kill weird URLs."
+
+### Good PR Descriptions
+
+#### Functionality change
+
+Example:
+
+> rpc: remove size limit on RPC server message freelist.
+>
+> Servers like FizzBuzz have very large messages and would benefit from reuse. Make the freelist larger, and add a goroutine that frees the freelist entries slowly over time, so that idle servers eventually release all freelist entries.
+
+The first few words describe what the PR actually does. The rest of the description talks about the problem being solved, why this is a good solution, and a bit more information about the specific implementation.
+
+#### Refactoring
+
+Example:
+
+> Construct a Task with a TimeKeeper to use its TimeStr and Now methods.
+> 
+> Add a Now method to Task, so the borglet() getter method can be removed (which was only used by OOMCandidate to call borglet’s Now method). This replaces the methods on Borglet that delegate to a TimeKeeper.
+> 
+> Allowing Tasks to supply Now is a step toward eliminating the dependency on Borglet. Eventually, collaborators that depend on getting Now from the Task should be changed to use a TimeKeeper directly, but this has been an accommodation to refactoring in small steps.
+> 
+> Continuing the long-range goal of refactoring the Borglet Hierarchy.
+
+The first line describes what the PR does and how this is a change from the past. The rest of the description talks about the specific implementation, the context of the PR, that the solution isn’t ideal, and possible future direction. It also explains why this change is being made.
+
+#### Small PR that needs some context
+
+Example:
+
+> Create a Python3 build rule for status.py.
+> 
+> This allows consumers who are already using this as in Python3 to depend on a rule that is next to the original status build rule instead of somewhere in their own tree. It encourages new consumers to use Python3 if they can, instead of Python2, and significantly simplifies some automated build file refactoring tools being worked on currently.
+
+The first sentence describes what’s actually being done. The rest of the description explains why the change is being made and gives the reviewer a lot of context.
+
+
+## Small PRs
+
+### Why Write Small PRs?
+
+* Reviewed more quickly.
+* Reviewed more thoroughly.
+* Less likely to introduce bugs.
+* Less wasted work if they are rejected.
+* Easier to merge.
+* Easier to design well.
+* Less blocking on reviews.
+* Simpler to roll back.
+
+Note that **reviewers have discretion to reject your change outright for the sole reason of it being too large**. 
+
+### What is Small
+
+In general, the right size for a PR is **one self-contained change**. This means that:
+
+* The PR makes a minimal change that addresses just one thing. 
+* The PR should include related test code.
+* Everything the reviewer needs to understand about the PR (except future development) is in the PR, the PR’s description, the existing codebase, or a PR they’ve already reviewed.
+* The system will continue to work well for its users and for the developers after the PR is checked in.
+* The PR is not so small that its implications are difficult to understand. If you add a new API, you should include a usage of the API in the same PR so that reviewers can better understand how the API will be used. This also prevents checking in unused APIs.
+
+> There are no hard and fast rules about how large is "too large." 100 lines is usually a reasonable size for a PR, and 1000 lines is usually too large, but it’s up to the judgment of your reviewer. 
+
+### Separate Out Refactorings
+
+It’s usually best to do refactorings in a separate PR from feature changes or bug fixes. For example, moving and renaming a class should be in a different PR from fixing a bug in that class. It is much easier for reviewers to understand the changes introduced by each PR when they are separate.
+
+### Keep related test code in the same PR
+
+A PR that adds or changes logic should be accompanied by new or updated tests for the new behavior. Pure refactoring PRs (that aren’t intended to change behavior) should also be covered by tests; ideally, these tests already exist, but if they don’t, you should add them.
+
+### Don't Break the Build
+
+If you have several PRs that depend on each other, you need to find a way to make sure the whole system keeps working after each PR is submitted. Otherwise you might break the build for all your fellow developers for a few minutes between your PR submissions (or even longer if something goes wrong unexpectedly with your later PR submissions).


### PR DESCRIPTION
Add code review and coding conventions guide.

`code-review-guide.md` are best practices from [Google Engineering Practices](https://google.github.io/eng-practices/), which would help us establish some code review standards.
`the-pr-author-guide-to-getting-through-code-review.md` from Google will help our contributors to create PRs of good quality. 
`coding-conventions.md` are some highlights from the Kubernetes community