### PR TITLE
Request to add FeynmanZhou and linuxsuren as the root owner

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,8 @@
 approvers:
     - zryfish
     - rayzhou2017
+    - linuxsuren
+    - FeynmanZhou
 
 reviewers:
     - rayzhou2017

--- a/sig-advocacy-and-outreach/OWNERS
+++ b/sig-advocacy-and-outreach/OWNERS
@@ -1,7 +1,3 @@
-approvers:
-  - linuxsuren
-  - FeynmanZhou
-  - shaowenchen
 reviewers:
   - shenhonglei
   - webup


### PR DESCRIPTION
@FeynmanZhou and @LinuxSuRen both have nearly 18 contributions on this repo. They are all the leaders of [Advocacy and Outreach Special Interest Group](https://github.com/kubesphere/community/tree/master/sig-advocacy-and-outreach). They are both very active.

So, I believe they can help to maintain this repo.
 