### PR TITLE
Add mango to sig-devops member

### DIFF
--- a/sig-devops/README.md
+++ b/sig-devops/README.md
@@ -9,6 +9,7 @@ The DevOps SIG is to design and implement the DevOps functionalities including p
 - Rick ([@linuxsuren](https://github.com/linuxSuRen/)), Member
 - Harrison Liu ([@harrisonliu5](https://github.com/harrisonliu5)), Member
 - John Niang ([@johnniang](https://github.com/JohnNiang)), Member
+- mango ([@mangoGoForward](https://github.com/mangoGoForward)), Member
 
 ## Documents
 


### PR DESCRIPTION
In `sig-devops` realm, @mangoGoForward has done too many contributions and he is very willing to contribute further more. 

So I add him into `sig-devops` team through this PR.