### PR TITLE
Rick is going to step off of the lead position

### DIFF
--- a/sig-advocacy-and-outreach/README.md
+++ b/sig-advocacy-and-outreach/README.md
@@ -7,7 +7,7 @@ and attract new people to join KubeSphere community.
 ## Members
 
 - Pengfei Zhou ([@FeynmanZhou](https://github.com/FeynmanZhou)), Lead
-- Rick ([@linuxsuren](https://github.com/linuxSuRen/)), Lead
+- Rick ([@linuxsuren](https://github.com/linuxSuRen/)), Member
 - Shaowen Chen ([@shaowenchen](https://github.com/shaowenchen)), Member
 - Honglei ([@shenhonglei](https://github.com/shenhonglei/)), Member
 - webup ([@webup](https://github.com/webup/)), Member

--- a/sig-advocacy-and-outreach/summer-ospp/OWNERS
+++ b/sig-advocacy-and-outreach/summer-ospp/OWNERS
@@ -1,5 +1,4 @@
 approvers:
-  - linuxsuren
   - FeynmanZhou
   - shenhonglei
 


### PR DESCRIPTION
So glad that there are many active members of the SIG Advocacy and Outreach. And not all the members on this page, you can reach out to them in the WeChat group if you want. Please contact any of us, or me (WeChat ID: `linuxsuren`).

Consider I need to pay more attention to the SIG DevOps before we have more active members of it. So, I don't have enough energy to lead the SIG Advocacy and Outreach.

/cc @kubesphere/sig-advocacy-and-outreach 