### PR TITLE
Request to add faweizhao26 and yangchuansheng as the owner 

### DIFF
--- a/sig-advocacy-and-outreach/OWNERS
+++ b/sig-advocacy-and-outreach/OWNERS
@@ -1,7 +1,12 @@
+approvers:
+    - faweizhao26
+    - yangchuansheng
+
 reviewers:
-  - shenhonglei
-  - webup
-  - faweizhao26
-  - FeynmanZhou
-  - shaowenchen
-  - linuxsuren
+    - shenhonglei
+    - webup
+    - faweizhao26
+    - FeynmanZhou
+    - shaowenchen
+    - linuxsuren
+    - yangchuansheng


### PR DESCRIPTION
Request to add faweizhao26 and yangchuansheng as the owner of advocacy-and-outreach sig.

@faweizhao26 and @yangchuansheng are all the members of [Advocacy and Outreach Special Interest Group](https://github.com/kubesphere/community/tree/master/sig-advocacy-and-outreach). They are also very active.

So, They can help to maintain this repo.

In addition，faweizhao26 is the administrator of ospp-2022. It will help him manage the projects if he is the owner.

Signed-off-by: faweizhao26 <faweizhao@kubesphere.io>